### PR TITLE
Discordリンクの位置を一番上に修正

### DIFF
--- a/src/components/FixedLinks.astro
+++ b/src/components/FixedLinks.astro
@@ -14,15 +14,15 @@ const LINKS: {
   scale?: number;
 }[] = [
   {
-    href: "https://x.com/" + ID,
-    title: "X: @" + ID,
-    logo: XLogo,
-  },
-  {
     href: DISCORD_URL,
     title: "ご依頼やご相談は、この Discord サーバーにて受け付けております。",
     logo: DiscordLogo,
     scale: 1.4,
+  },
+  {
+    href: "https://x.com/" + ID,
+    title: "X: @" + ID,
+    logo: XLogo,
   },
 ];
 ---


### PR DESCRIPTION
このプルリクエストでは、`src/components/FixedLinks.astro` ファイル内の `LINKS` 定数に軽微な修正を加えています。具体的には、Xプラットフォームへのリンクの表示順を変更し、リストの末尾に移動させました。

- [`src/components/FixedLinks.astro`](diffhunk://#diff-ae15b434dc91d9c2788bee861ded6e38b991360b9330fce1ed6b039dfbb2d0c6L16-R26): `LINKS` 定数内におけるXプラットフォームへのリンクの表示順を変更し、Discordサーバーへのリンクの後に配置するように修正しました。
